### PR TITLE
Adds a new dictionary without stop words and adjusts sql query strings

### DIFF
--- a/lib/text_search/query.rb
+++ b/lib/text_search/query.rb
@@ -14,9 +14,9 @@ module TextSearch
       # [query] is in single qoutes to allow special characters
       # :* allows [query] to be a prefix for a term
       if @query.size == 0
-        "to_tsquery('english', '')"
+        "to_tsquery('english_no_stop_words', '')"
       else
-        @query.map { |q| "to_tsquery('english', '#{q}:*')" }.join(' || ')
+        @query.map { |q| "to_tsquery('english_no_stop_words', '#{q}:*')" }.join(' || ')
       end
     end
   end

--- a/spec/dummy/app/models/parent.rb
+++ b/spec/dummy/app/models/parent.rb
@@ -18,4 +18,13 @@ class Parent < ActiveRecord::Base
           value_2: 2,
       }
   }, highlight: true
+
+  scope :english_no_stop_words, -> {
+    ActiveRecord::Base.connection.execute('
+      CREATE TEXT SEARCH DICTIONARY english_no_stop_words (TEMPLATE = pg_catalog.english_stem);
+      CREATE TEXT SEARCH CONFIGURATION english_no_stop_words (PARSER = default);
+      ALTER TEXT SEARCH CONFIGURATION english_no_stop_words
+        ALTER MAPPING FOR asciiword, asciihword, hword_asciipart, hword, hword_part, word WITH english_no_stop_words;'
+    );
+  }
 end


### PR DESCRIPTION
* Summary of problem
  * This uses `to_tsvector('english', ...` and `to_tsquery('english', "'[query]':*")` for the SQL queries
  * Here’s a good article on [tsvector](https://www.compose.com/articles/mastering-postgresql-tools-full-text-search-and-phrase-search/)
  * The problem is that the `english` regconfig removes [these stopwords](https://www.ranks.nl/stopwords)
  * So, anytime one of those stopwords is queried (`Me` happens to be one of them), then it won’t return anything.
  * Here’s a reference [example](https://stackoverflow.com/questions/1497895/can-i-configure-postgresql-programmatically-to-not-eliminate-stop-words-in-full)

* How to test the problem locally
    * Go to http://localhost:3000/users?limit=25&&search_term=M in the main app
      * Should return a json array of several objects
    * Go to http://localhost:3000/users?limit=25&&search_term=Me in the main app
      * You should return a json array with 0 object
      * (This is because `Me` is an english stop word)
      * You can alternately query any of the English stop words and get 0 results

* Solution
  * This PR creates our own english-based dictionary w/o stopwords 
  * It also updates our sql-creators to use the newly created dictionary w/o stopwords
  * Test by changing the Gem file in the main app to import a local version of this branch instead of the hard-coded github address. Go to the urls mentioned above and you will get results.