### PR TITLE
Updates query sql to use english_no_stop_words

### DIFF
--- a/lib/text_search/query.rb
+++ b/lib/text_search/query.rb
@@ -13,10 +13,12 @@ module TextSearch
       # to_tsquery('english', "'[query]':*")
       # [query] is in single qoutes to allow special characters
       # :* allows [query] to be a prefix for a term
+      # `english_no_stop_words` is a custom dictionary w/o stopwords.
+      # Added via a migration file to database
       if @query.size == 0
-        "to_tsquery('english', '')"
+        "to_tsquery('english_no_stop_words', '')"
       else
-        @query.map { |q| "to_tsquery('english', '#{q}:*')" }.join(' || ')
+        @query.map { |q| "to_tsquery('english_no_stop_words', '#{q}:*')" }.join(' || ')
       end
     end
   end


### PR DESCRIPTION
**Context**
- This repo uses `to_tsvector('english', ...` and `to_tsquery('english', "'[query]':*")` for SQL queries
- Here’s a good article on [tsvector](https://www.compose.com/articles/mastering-postgresql-tools-full-text-search-and-phrase-search)
- The problem is that the ‘english’ regconfig removes [these stopwords](https://www.ranks.nl/stopwords)
- So, anytime one of those stopwords is queried (e.g. “Me”), then it won’t return anything

**Solution**
- Use an english-based dictionary with stopwords. Requires that users of this library define `english_no_stop_words` in their repos as well.

Related [stackoverflow example](https://stackoverflow.com/questions/1497895/can-i-configure-postgresql-programmatically-to-not-eliminate-stop-words-in-full)